### PR TITLE
Add support for `node_confirms` option on PUTS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop-2.2"}}}
+   {riakc, ".*", {git, "git://github.com/nhs-riak/riak-erlang-client", {branch, "develop-2.2"}}}
   ]}.
 {edoc_opts,
  [

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}}
+   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop-2.2"}}}
   ]}.
 {edoc_opts,
  [

--- a/src/rhc.erl
+++ b/src/rhc.erl
@@ -909,14 +909,14 @@ get_q_params(Rhc, Options) ->
 %% @doc Extract the list of query parameters to use for a PUT
 %% @spec put_q_params(rhc(), proplist()) -> proplist()
 put_q_params(Rhc, Options) ->
-    options_list([r,w,dw,pr,pw,timeout,asis,{return_body,"returnbody"}],
+    options_list([r,w,dw,pr,pw,timeout,asis,node_confirms,{return_body,"returnbody"}],
                  Options ++ options(Rhc)).
 
 %% @doc Extract the list of query parameters to use for a
 %% counter increment
 -spec counter_q_params(rhc(), list()) -> list().
 counter_q_params(Rhc, Options) ->
-    options_list([r, pr, w, pw, dw, returnvalue, basic_quorum, notfound_ok], Options ++ options(Rhc)).
+    options_list([r, pr, w, pw, dw, returnvalue, basic_quorum, node_confirms, notfound_ok], Options ++ options(Rhc)).
 
 %% @doc Extract the list of query parameters to use for a DELETE
 %% @spec delete_q_params(rhc(), proplist()) -> proplist()
@@ -927,7 +927,8 @@ fetch_type_q_params(Rhc, Options) ->
     options_list([r,pr,basic_quorum,notfound_ok,timeout,include_context], Options ++ options(Rhc)).
 
 update_type_q_params(Rhc, Options) ->
-    options_list([r,w,dw,pr,pw,basic_quorum,notfound_ok,timeout,include_context,{return_body, "returnbody"}],
+    options_list([r,w,dw,pr,pw,basic_quorum, node_confirms,
+                  notfound_ok,timeout,include_context,{return_body, "returnbody"}],
                  Options ++ options(Rhc)).
 
 %% @doc Extract the options for the given `Keys' from the possible


### PR DESCRIPTION
And counter incr/decr and datatype operations. NOTE: depends on
`node_confirms` work in riak-2.2.5